### PR TITLE
Imported Resource, ResourceReview in User to fix setup_dev

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,3 +4,4 @@ module (as opposed to just their python files)
 """
 
 from user import *  # noqa
+from resource import *  # noqa

--- a/app/models/resource.py
+++ b/app/models/resource.py
@@ -10,6 +10,7 @@ class Resource(db.Model):
     # address_id = db.Column(db.Integer, db.ForeignKey('addresses.id'))
     reviews = db.relationship('ResourceReview', backref='resource',
                               lazy='dynamic')
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
 
     def __repr__(self):
         return '<Resource \'%s\'>' % self.name

--- a/app/models/resource.py
+++ b/app/models/resource.py
@@ -7,7 +7,7 @@ class Resource(db.Model):
     name = db.Column(db.String(64))
     description = db.Column(db.Text)
     website = db.Column(db.Text)
-    address_id = db.Column(db.Integer, db.ForeignKey('addresses.id'))
+    # address_id = db.Column(db.Integer, db.ForeignKey('addresses.id'))
     reviews = db.relationship('ResourceReview', backref='resource',
                               lazy='dynamic')
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -4,6 +4,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from itsdangerous import TimedJSONWebSignatureSerializer as Serializer, \
     BadSignature, SignatureExpired
 from .. import db, login_manager
+from resource import Resource, ResourceReview  # noqa
 
 
 class Permission:
@@ -53,6 +54,7 @@ class User(UserMixin, db.Model):
     email = db.Column(db.String(64), unique=True, index=True)
     password_hash = db.Column(db.String(128))
     role_id = db.Column(db.Integer, db.ForeignKey('roles.id'))
+    resources = db.relationship('Resource', backref='user', lazy='dynamic')
     resource_reviews = db.relationship('ResourceReview', backref='user',
                                        lazy='dynamic')
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -4,7 +4,6 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from itsdangerous import TimedJSONWebSignatureSerializer as Serializer, \
     BadSignature, SignatureExpired
 from .. import db, login_manager
-from resource import Resource, ResourceReview  # noqa
 
 
 class Permission:


### PR DESCRIPTION
r @aharelick 
- commented out address_id in Resource because table does not exist
- added # noqa to end of import line bc linter complained that import uunused, yet import fixed setup_dev
- also added relationship between one User and many Reviews
