### PR TITLE
Changed structure and color of nav bar

### DIFF
--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -19,7 +19,13 @@
 
 {% macro action_items(current_user) %}
     {% if current_user.is_authenticated() %}
-        <a class="item">Search Users</a>
+        <div class="item ui mini search">
+          <div class="ui icon input">
+            <input class="prompt" type="text" placeholder="Search...">
+            <i class="search icon"></i>
+          </div>
+          <div class="results"></div>
+        </div>
         <a class="item">Resources</a>
         <a class="item">Map</a>
         <a class="item">Donate</a>

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -17,19 +17,30 @@
     {% endif %}
 {% endmacro %}
 
-{% macro account_items(current_user) %}
+{% macro action_items(current_user) %}
     {% if current_user.is_authenticated() %}
-        <a href="{{ url_for('account.manage') }}" class="item">Your Account</a>
-        <a href="{{ url_for('account.logout') }}" class="item">Log out</a>
-    {% else %}
-        <a href="{{ url_for('account.register') }}" class="item">Register</a>
-        <a href="{{ url_for('account.login') }}" class="item">Log in</a>
+        <a class="item">Search Users</a>
+        <a class="item">Resources</a>
+        <a class="item">Map</a>
+        <a class="item">Donate</a>
     {% endif %}
+{% endmacro %}
+
+{% macro account_loggedin_items(current_user) %}
+    <a class="item">View Profile</a>
+    <a href="{{ url_for('account.manage') }}" class="item">Account Settings</a>
+    <a class="item">Help</a>
+    <a href="{{ url_for('account.logout') }}" class="item">Log out</a>
+{% endmacro %}
+
+{% macro account_loggedout_items() %}
+    <a href="{{ url_for('account.register') }}" class="item">Register</a>
+    <a href="{{ url_for('account.login') }}" class="item">Log in</a>
 {% endmacro %}
 
 {% macro mobile_nav(current_user, endpoints=None) %}
     <div class="mobile only row">
-        <div class="ui fixed inverted black main menu">
+        <div class="ui fixed inverted red main menu">
             {{ header_items(current_user) }}
             <div class="right menu">
                 <a class="icon item" id="open-nav"><i class="sidebar icon"></i></a>
@@ -41,7 +52,13 @@
             {% if endpoints %}
                 {{ render_menu_items(endpoints) }}
             {% endif %}
-            {{ account_items(current_user) }}
+            {% if current_user.is_authenticated() %}
+                {{ account_loggedin_items(current_user) }}
+                {{ action_items(current_user) }}
+            {% else %}
+                {{ account_loggedout_items() }}
+            {% endif %}
+            
         </div>
     </div>
 {% endmacro %}
@@ -50,11 +67,23 @@
  # secondary menu. `count` should be the string (e.g. 'four') number of endpoints. #}
 {% macro desktop_nav(current_user, endpoints=None, count=None) %}
     <div class="computer tablet only row">
-        <div class="ui fixed inverted black main menu">
+        <div class="ui fixed inverted red main menu">
             <div class="ui container">
                 {{ header_items(current_user) }}
+
                 <div class="right menu">
-                    {{ account_items(current_user) }}
+                    {% if current_user.is_authenticated() %}
+                        {{ action_items(current_user) }}
+                        <div class="ui dropdown item">
+                            <div class="text">{{current_user.first_name}}</div>
+                            <i class="dropdown icon"></i>
+                            <div class="menu">
+                                {{ account_loggedin_items(current_user) }}
+                            </div>
+                        </div>
+                    {% else %}
+                        {{ account_loggedout_items() }}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -17,14 +17,14 @@
     {% endif %}
 {% endmacro %}
 
-{% macro action_items(current_user) %}
+{% macro page_items(current_user) %}
     {% if current_user.is_authenticated() %}
         <div class="item ui mini search">
-          <div class="ui icon input">
-            <input class="prompt" type="text" placeholder="Search...">
-            <i class="search icon"></i>
-          </div>
-          <div class="results"></div>
+            <div class="ui icon input">
+                <input class="prompt" type="text" placeholder="Search...">
+                <i class="search icon"></i>
+            </div>
+            <div class="results"></div>
         </div>
         <a class="item">Resources</a>
         <a class="item">Map</a>
@@ -32,14 +32,14 @@
     {% endif %}
 {% endmacro %}
 
-{% macro account_loggedin_items(current_user) %}
+{% macro account_items_logged_in(current_user) %}
     <a class="item">View Profile</a>
     <a href="{{ url_for('account.manage') }}" class="item">Account Settings</a>
     <a class="item">Help</a>
     <a href="{{ url_for('account.logout') }}" class="item">Log out</a>
 {% endmacro %}
 
-{% macro account_loggedout_items() %}
+{% macro account_items_logged_out() %}
     <a href="{{ url_for('account.register') }}" class="item">Register</a>
     <a href="{{ url_for('account.login') }}" class="item">Log in</a>
 {% endmacro %}
@@ -59,10 +59,10 @@
                 {{ render_menu_items(endpoints) }}
             {% endif %}
             {% if current_user.is_authenticated() %}
-                {{ action_items(current_user) }}
-                {{ account_loggedin_items(current_user) }}
+                {{ page_items(current_user) }}
+                {{ account_items_logged_in(current_user) }}
             {% else %}
-                {{ account_loggedout_items() }}
+                {{ account_items_logged_out() }}
             {% endif %}
             
         </div>
@@ -79,16 +79,16 @@
 
                 <div class="right menu">
                     {% if current_user.is_authenticated() %}
-                        {{ action_items(current_user) }}
+                        {{ page_items(current_user) }}
                         <div class="ui dropdown item">
                             <div class="text">{{current_user.first_name}}</div>
                             <i class="dropdown icon"></i>
                             <div class="menu">
-                                {{ account_loggedin_items(current_user) }}
+                                {{ account_items_logged_in(current_user) }}
                             </div>
                         </div>
                     {% else %}
-                        {{ account_loggedout_items() }}
+                        {{ account_items_logged_out() }}
                     {% endif %}
                 </div>
             </div>

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -59,8 +59,8 @@
                 {{ render_menu_items(endpoints) }}
             {% endif %}
             {% if current_user.is_authenticated() %}
-                {{ account_loggedin_items(current_user) }}
                 {{ action_items(current_user) }}
+                {{ account_loggedin_items(current_user) }}
             {% else %}
                 {{ account_loggedout_items() }}
             {% endif %}

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -64,7 +64,6 @@
             {% else %}
                 {{ account_items_logged_out() }}
             {% endif %}
-            
         </div>
     </div>
 {% endmacro %}
@@ -76,7 +75,6 @@
         <div class="ui fixed inverted red main menu">
             <div class="ui container">
                 {{ header_items(current_user) }}
-
                 <div class="right menu">
                     {% if current_user.is_authenticated() %}
                         {{ page_items(current_user) }}


### PR DESCRIPTION
@aharelick 

Updated nav bar:
- [x] Change color to red
- [x] Move account management and log out to under 'Name' dropdown, along with new tabs for 'View Profile' and 'Help'
- [x] Create tabs for 'Search Users', 'Resources', 'Map', and 'Donate'
- [x] Keep everything responsive - in mobile, all tabs move under hamburger menu icon
- [x] Make 'Search users' into a search bar instead of button

Currently, only 'Register', 'Log in', 'Account Settings' and 'Log out' are backed by real links, the rest are waiting to be fill in. 
##### Logged out desktop:

<img width="1202" alt="screen shot 2015-11-14 at 11 05 46 am" src="https://cloud.githubusercontent.com/assets/4624022/11164489/1bba2096-8ac0-11e5-851f-07dbd18bae1b.png">
##### Logged out tablet/mobile:

<img width="717" alt="screen shot 2015-11-14 at 11 05 56 am" src="https://cloud.githubusercontent.com/assets/4624022/11164491/2339dee2-8ac0-11e5-935f-cbd7edeb9387.png">
<img width="686" alt="screen shot 2015-11-14 at 11 14 21 am" src="https://cloud.githubusercontent.com/assets/4624022/11164512/ea359bf8-8ac0-11e5-9eb6-f15e625b9e23.png">
##### Logged in desktop:

<img width="1206" alt="screen shot 2015-11-14 at 11 06 47 am" src="https://cloud.githubusercontent.com/assets/4624022/11164492/28481dd6-8ac0-11e5-8524-395e593e4ba1.png">
<img width="542" alt="screen shot 2015-11-14 at 11 07 18 am" src="https://cloud.githubusercontent.com/assets/4624022/11164494/34d609a0-8ac0-11e5-94d8-0b1460c353ba.png">
##### Logged in tablet/mobile:

<img width="763" alt="screen shot 2015-11-14 at 11 07 06 am" src="https://cloud.githubusercontent.com/assets/4624022/11164493/2def0da8-8ac0-11e5-93d0-982088f092d9.png">
<img width="696" alt="screen shot 2015-11-14 at 11 08 31 am" src="https://cloud.githubusercontent.com/assets/4624022/11164495/373555fc-8ac0-11e5-8816-5462b5a3c8ce.png">
